### PR TITLE
Add ensurePublic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Take a list describing a set of sections and callback with a list of actual sect
 
 ### var extrapolate = require('cf-section-extrapolator')
 
-### extrapolate(sectionService, currentSectionId, desiredSections, cb)
+### extrapolate(sectionService, currentSectionId, desiredSections, options={}, cb)
 
 - `sectionService` is a service that has a `findPublic(query, cb)` method
 - `currentSectionId` is the stringy id of the current section
@@ -68,6 +68,15 @@ sectionize(sectionService, currentSectionId, desiredSections, function (err, ids
   // ids == [ '789' ]
 })
 ```
+
+## Options
+
+##### ensurePublic
+
+Type: `boolean`
+Default: `true`
+
+Determines whether the section lookup is performed as a `findPublic` or a `find`.
 
 ## Credits
 Built by developers at [Clock](http://clock.co.uk).

--- a/extrapolator.js
+++ b/extrapolator.js
@@ -6,12 +6,21 @@ var requiredFields = [ '_id', 'parent' ]
  * Extrapolate some actual section ids from a description of desired sections,
  * given a section service and the current section id.
  */
-function extrapolate(sectionService, currentSectionId, desiredSections, cb) {
+function extrapolate(sectionService, currentSectionId, desiredSections, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
 
   var sectionIds = []
+    , findFn = sectionService.findPublic
+
+  if (opts.ensurePublic === false) {
+    findFn = sectionService.find
+  }
 
   // Get all of the publicly available sections
-  sectionService.findPublic({}, { fields: requiredFields }, function (err, sections) {
+  findFn({}, { fields: requiredFields }, function (err, sections) {
 
     if (err) return cb(err)
 

--- a/test/extrapolator.test.js
+++ b/test/extrapolator.test.js
@@ -51,4 +51,16 @@ describe('Section Extrapolator', function () {
     })
   })
 
+  it('should extrapolate ids of non public and public sections when ensurePublic is set to false', function (done) {
+    var opts = { ensurePublic: false }
+      , sections = [
+        { id: '8', includeSubSections: false }
+      , { id: '1', includeSubSections: false }
+      ]
+    extrapolate(sectionService, '1', sections, opts, function (err, ids) {
+      if (err) return done(err)
+      assert.deepEqual(ids, [ '8', '1' ])
+      done()
+    })
+  })
 })

--- a/test/mock-section-service.js
+++ b/test/mock-section-service.js
@@ -2,6 +2,11 @@ var sectionFixtures = require('./section-fixtures')
 
 module.exports =
 { findPublic: function (a, b, cb) {
+    return cb(null, sectionFixtures.filter(function (fixture) {
+      return fixture.visible
+    }))
+  }
+, find: function (a, b, cb) {
     return cb(null, sectionFixtures)
   }
 , getChildSections: function getChildSections(parent, sections, maxDepth, depth) {

--- a/test/section-fixtures.js
+++ b/test/section-fixtures.js
@@ -16,4 +16,5 @@ module.exports =
   , { _id: '5', visible: true, parent: null }
   , { _id: '6', visible: true, parent: null }
   , { _id: '7', visible: true, parent: null }
+  , { _id: '8', visible: false, parent: null }
   ]


### PR DESCRIPTION
This adds an options hash and the `ensurePublic` option, which defaults to `true`.

When `ensurePublic` is false, the `findPublic` that this module performs becomes
a `find`. This fixes an issue that can arise through the use of this module in
clocklimited/cf-list-aggregator when you are trying to build up an automatic list,
and some sections that feed that list are not public, but the articles under
them are publicly viewable.

@bengourley this will also require a release of clocklimited/cf-list-aggregator
once its merged here.
